### PR TITLE
Support struct-uniforms

### DIFF
--- a/example/src/main/scala/CartonShader.scala
+++ b/example/src/main/scala/CartonShader.scala
@@ -17,18 +17,17 @@
 import com.jsuereth.gl.shaders._
 import com.jsuereth.gl.math._
 import com.jsuereth.gl.texture.Texture2D
+import com.jsuereth.gl.io.ShaderUniformLoadable
 
 import delegate com.jsuereth.gl.math._
 
-object CartoonShader extends DslShaderProgram {
-  // Used for vertex shader
-  val modelMatrix = Uniform[Matrix4[Float]]()
-  val viewMatrix = Uniform[Matrix4[Float]]()
-  val projectionMatrix = Uniform[Matrix4[Float]]()
+case class WorldData(light: Vec3[Float], eye: Vec3[Float], view: Matrix4[Float], projection: Matrix4[Float]) derives ShaderUniformLoadable
 
-  // Used for pixel shader / lighting model
-  val lightPosition = Uniform[Vec3[Float]]()
-  val eyePosition = Uniform[Vec3[Float]]()
+object CartoonShader extends DslShaderProgram {
+  // Hack to get structures to work.  OpenGL spec + reality may not line up on how to look up structure ids.  Need to rethink
+  // ShaderUniformLoadable class...
+  val world = makeUniform[WorldData]("world.light")
+  val modelMatrix = Uniform[Matrix4[Float]]()
   val materialShininess = Uniform[Float]()
   val materialKd = Uniform[Float]()
   val materialKs = Uniform[Float]()
@@ -44,13 +43,13 @@ object CartoonShader extends DslShaderProgram {
     val worldNormal = (modelMatrix() * Vec4(inNormal, 0)).xyz
     // Note: We have to do this dance to feed this into fragment shader.
     val texCoord: Vec2[Float] = texPosition
-    glPosition(projectionMatrix() * viewMatrix() * modelMatrix() * Vec4(inPosition, 1))
+    glPosition(world().projection * world().view * modelMatrix() * Vec4(inPosition, 1))
     // Fragment shader
     fragmentShader {
-      val L = (lightPosition() - worldPos).normalize
+      val L = (world().light - worldPos).normalize
       val N = worldNormal.normalize
       val lambertian = Math.max(L.dot(N), 0.0f).toFloat
-      val V = (eyePosition() - worldPos).normalize
+      val V = (world().eye - worldPos).normalize
       val H = (L + V).normalize
       val diffuse = materialKd() * lambertian
       val specular =

--- a/example/src/main/scala/CartonShader.scala
+++ b/example/src/main/scala/CartonShader.scala
@@ -26,7 +26,7 @@ case class WorldData(light: Vec3[Float], eye: Vec3[Float], view: Matrix4[Float],
 object CartoonShader extends DslShaderProgram {
   // Hack to get structures to work.  OpenGL spec + reality may not line up on how to look up structure ids.  Need to rethink
   // ShaderUniformLoadable class...
-  val world = makeUniform[WorldData]("world.light")
+  val world = Uniform[WorldData]()
   val modelMatrix = Uniform[Matrix4[Float]]()
   val materialShininess = Uniform[Float]()
   val materialKd = Uniform[Float]()

--- a/example/src/main/scala/Main.scala
+++ b/example/src/main/scala/Main.scala
@@ -49,6 +49,12 @@ object Main {
 
     def run(): Unit = {
         System.out.println("Hello LWJGL " + Version.getVersion() + "!");
+        System.out.println("Example shaders")
+        System.out.println("--- Vertex Shader ---")
+        System.out.println(CartoonShader.vertexShaderCode)
+        System.out.println("--- Fragment Shader ---")
+        System.out.println(CartoonShader.fragmentShaderCode)
+        System.out.println("---  ---")
         try {
             init()
             loop()
@@ -168,6 +174,13 @@ object Main {
         val vao = withMemoryStack(mesh.loadVao)
         CartoonShader.load()
 
+        System.out.println("-- Shader struct debug --")
+        System.out.println(s" world: ${CartoonShader.debugUniform("world")}")
+        System.out.println(s" world.light: ${CartoonShader.debugUniform("world.light")}")
+        System.out.println(s" world.eye: ${CartoonShader.debugUniform("world.eye")}")
+        System.out.println(s" world.view: ${CartoonShader.debugUniform("world.view")}")
+        System.out.println(s" world.projection: ${CartoonShader.debugUniform("world.projection")}")
+
         // Render a scene using cartoon shader.
         def render(): Unit = {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT) // clear the framebuffer
@@ -183,11 +196,10 @@ object Main {
                     val stack = the[MemoryStack]
                     val textures = ActiveTextures()
                 }
-
-                CartoonShader.projectionMatrix := projectionMatrix
-                CartoonShader.lightPosition := scene.lights.next
-                CartoonShader.viewMatrix := scene.camera.viewMatrix
-                CartoonShader.eyePosition := scene.camera.eyePosition
+                CartoonShader.world := WorldData(light = scene.lights.next,
+                                                 eye = scene.camera.eyePosition,
+                                                 view = scene.camera.viewMatrix,
+                                                 projection = projectionMatrix)
                 CartoonShader.materialKdTexture := uglyTexture
                 for (o <- scene.objectsInRenderOrder) {
                     env.push()

--- a/example/src/main/scala/Main.scala
+++ b/example/src/main/scala/Main.scala
@@ -184,7 +184,7 @@ object Main {
         // Render a scene using cartoon shader.
         def render(): Unit = {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT) // clear the framebuffer
-            glEnable(GL_DEPTH)
+            glEnable(GL_DEPTH_TEST)
             glEnable(GL_CULL_FACE)
             glCullFace(GL_BACK)
             glEnable(GL_TEXTURE)

--- a/io/src/main/scala/com/jsuereth/gl/io/VaoAttribute.scala
+++ b/io/src/main/scala/com/jsuereth/gl/io/VaoAttribute.scala
@@ -40,6 +40,7 @@ inline def sizeOf[T]: Int = inline erasedValue[T] match {
     case _: Vec4[t] => 4*sizeOf[t] 
     case _: Matrix4x4[t] => 16*sizeOf[t]
     case _: Matrix3x3[t] => 9*sizeOf[t]
+    // TODO - SizedArray opaque type...
     case _: (a *: b) => sizeOf[a]+sizeOf[b]
     case _: Product => implicit match {
         case m: Mirror.ProductOf[T] => sizeOf[m.MirroredElemTypes]
@@ -145,7 +146,7 @@ inline def vaoAttributes[T]: Array[VaoAttribute] = {
                                   attr[c](2, stride, sizeOf[a]+sizeOf[b]),
                                   attr[d](3, stride, sizeOf[a]+sizeOf[b]+sizeOf[c]))
     case _: Product =>
-      implicit match {
+      delegate match {
         case m: Mirror.ProductOf[T] => vaoAttributes[m.MirroredElemTypes]
       }
     case _ => compiletime.error("Cannot compute the VAO attributes of this type.")

--- a/io/src/test/scala/com/jsuereth/gl/io/TestBufferLoadable.scala
+++ b/io/src/test/scala/com/jsuereth/gl/io/TestBufferLoadable.scala
@@ -1,0 +1,38 @@
+package com.jsuereth.gl
+package io
+package testbufferlodable
+
+import math._
+
+import org.junit.Test
+import org.junit.Assert._
+import java.nio.ByteBuffer
+
+case class ExamplePod(x: Vec3[Float], y: Vec2[Int], z: Vec2[Boolean]) derives BufferLoadable
+class TestBufferLoadable {
+
+    @Test def derivedLoadableWorks(): Unit = {
+        val buf = ByteBuffer.allocate(sizeOf[ExamplePod])
+        buf.load(ExamplePod(Vec3(1f,2f,3f), Vec2(4,5), Vec2(true, false)))
+        buf.flip
+        assertEquals(1f, buf.getFloat)
+        assertEquals(2f, buf.getFloat)
+        assertEquals(3f, buf.getFloat)
+        assertEquals(4, buf.getInt)
+        assertEquals(5, buf.getInt)
+        assertEquals(1.toByte, buf.get)
+        assertEquals(0.toByte, buf.get)
+    }
+    @Test def primitiveWorks(): Unit = {
+        val buf = ByteBuffer.allocate(12)
+        buf.load(1f)
+        buf.load(2)
+        buf.load(false)
+        buf.load(2.toByte)
+        buf.flip
+        assertEquals(1f, buf.getFloat)
+        assertEquals(2, buf.getInt)
+        assertEquals(0.toByte, buf.get)
+        assertEquals(2.toByte, buf.get)
+    }
+}

--- a/io/src/test/scala/com/jsuereth/gl/io/TestShaderUniformLoadable.scala
+++ b/io/src/test/scala/com/jsuereth/gl/io/TestShaderUniformLoadable.scala
@@ -1,0 +1,33 @@
+package com.jsuereth.gl
+package io
+
+import org.junit.Test
+import org.junit.Assert._
+import org.lwjgl.opengl.GL11.{GL_FLOAT, GL_INT, GL_SHORT, GL_BYTE,GL_DOUBLE}
+
+case class UniformExamplePod(one: math.Vec2[Int], two: math.Vec3[Float])
+case class UniformExamplePod2(one: math.Vec2[Int], two: math.Vec3[Float], three: math.Vec2[Float], four: math.Vec2[Float])
+case class UniformExamplePod3(one: math.Vec2[Int], two: UniformExamplePod)
+
+class TestUniformSize {
+    import ShaderUniformLoadable.uniformSize
+
+     @Test def sizeOfPrimitive(): Unit = {
+        assertEquals(1, uniformSize[math.Vec2[Int]])
+        assertEquals(1, uniformSize[math.Vec3[Float]])
+        assertEquals(1, uniformSize[math.Matrix4x4[Float]])
+    }
+    @Test def sizeOfStruct(): Unit = {
+        assertEquals(2, uniformSize[UniformExamplePod])
+        // Recursive size test.
+        assertEquals(3, uniformSize[UniformExamplePod3])
+        assertEquals(4, uniformSize[UniformExamplePod2])
+    }
+
+    // The test here is if we compile.  Calling OpenGL at this point will cause an error, since we have no gl context.
+    @Test def deriveUnfiromCompiles(): Unit = {
+        delegate testPod for ShaderUniformLoadable[UniformExamplePod] = ShaderUniformLoadable.derived[UniformExamplePod]
+        // Test nested derivation.
+        delegate testPod2 for ShaderUniformLoadable[UniformExamplePod3] = ShaderUniformLoadable.derived[UniformExamplePod3]
+    }
+}

--- a/shader/src/main/scala/com/jsuereth/gl/shaders/BasicShaderProgram.scala
+++ b/shader/src/main/scala/com/jsuereth/gl/shaders/BasicShaderProgram.scala
@@ -123,4 +123,7 @@ abstract class BasicShaderProgram {
     def makeUniform[T : ShaderUniformLoadable](name: String): Uniform[T] = {
       MyUniform[T](name)
     }
+
+    // Temporary for debugging purposes only.
+    def debugUniform(name: String): Int = GL20.glGetUniformLocation(programId, name)
 }

--- a/shader/src/main/scala/com/jsuereth/gl/shaders/DslShaderProgram.scala
+++ b/shader/src/main/scala/com/jsuereth/gl/shaders/DslShaderProgram.scala
@@ -45,6 +45,13 @@ object DslShaderProgram {
       }
     }
     inline def valName: String = ${valNameImpl}
+
+    def testStructDefImpl[T] given (r: tasty.Reflection, tpe: Type[T]): Expr[String] = {
+      import r._
+      val helpers = codegen.Convertors[r.type](r)
+      helpers.toStructDefinition(tpe.unseal.tpe).map(_.toProgramString).toString
+    }
+    inline def testStructDef[T] = ${testStructDefImpl[T]}
 }
 abstract class DslShaderProgram extends BasicShaderProgram {
 

--- a/shader/src/main/scala/com/jsuereth/gl/shaders/codegen/ast.scala
+++ b/shader/src/main/scala/com/jsuereth/gl/shaders/codegen/ast.scala
@@ -39,6 +39,8 @@ enum Declaration {
   case Output(name: String, tpe: String, location: Option[Int] = None)
   // TODO - method with args...
   case Method(name: String, tpe: String, block: Seq[Statement])
+  /** The definitiion of a struct. */
+  case Struct(name: String, members: Seq[StructMember])
 
   def toProgramString: String = this match {
     case Uniform(name, tpe) => s"uniform $tpe $name;"
@@ -47,7 +49,13 @@ enum Declaration {
     case Output(name, tpe, Some(location)) => s"layout (location = $location) out $tpe $name;"
     case Output(name, tpe, None) => s"out $tpe $name;"
     case Method(name, tpe, block) => s"$tpe $name() {\n  ${block.map(_.toProgramString).mkString("\n  ")}\n}"
+    case Struct(name, members) => s"struct $name {\n  ${members.map(_.toProgramString).mkString("\n  ")}\n};"
   }
+}
+
+/** A member of a structure. */
+case class StructMember(name: String, tpe: String) {
+  def toProgramString: String = s"$tpe $name;"
 }
 
 /** Statements in the GLSL language. */

--- a/shader/src/main/scala/com/jsuereth/gl/shaders/codegen/convertors.scala
+++ b/shader/src/main/scala/com/jsuereth/gl/shaders/codegen/convertors.scala
@@ -147,6 +147,12 @@ class Convertors[R <: tasty.Reflection](val r: R) {
       case Some(clsSym) => !clsSym.caseFields.isEmpty && !isOpaqueType(tpe)
       case None => false
     }
+    /** Returns the first member name of a structure type, if this is a structure type.   Note: This is a workaround. */
+    def firstStructMemberName(tpe: r.Type): Option[String] =
+      for {
+        struct <- toStructDefinition(tpe)
+        member <- struct.members.headOption
+      } yield member.name
 
 
     /** Extractor for detecting a "fragmentShader {}" block. */

--- a/shader/src/test/scala/com/jsuereth/gl/shaders/TestShader.scala
+++ b/shader/src/test/scala/com/jsuereth/gl/shaders/TestShader.scala
@@ -3,6 +3,7 @@ import org.junit.Assert._
 
 import com.jsuereth.gl.shaders._
 import com.jsuereth.gl.math._
+import com.jsuereth.gl.io._
 
 /** This is our target syntax. */
 // Attempt at cel-shading
@@ -47,9 +48,9 @@ object ExampleCartoonShader extends DslShaderProgram {
   }
 }
 
+
 class Test1 {
-  @Test def extractShaderProgramString(): Unit = {
-    val shader = ExampleCartoonShader
+  @Test def extractCartoonVertexShader(): Unit = {
     assertEquals(
 """#version 300 es
 
@@ -67,9 +68,9 @@ void main() {
   worldPos = ((modelMatrix * vec4(inPosition,1.0))).xyz;
   worldNormal = ((modelMatrix * vec4(inNormal,0.0))).xyz;
   gl_Position = (((projectionMatrix * viewMatrix) * modelMatrix) * vec4(inPosition,1.0));
-}""", shader.vertexShaderCode)
-    
-    
+}""", ExampleCartoonShader.vertexShaderCode)
+  }
+  @Test def extractCartoonFragmentShader(): Unit = {
     assertEquals(
 """#version 300 es
 
@@ -93,9 +94,9 @@ void main() {
   float edgeDetection = ((dot(V,worldNormal) > 0.3)) ? (1.0) : (0.0);
   float light = (edgeDetection * (diffuse + specular));
   color = vec4(light,light,light,1.0);
-}""", shader.fragmentShaderCode)
+}""", ExampleCartoonShader.fragmentShaderCode)
 
-    assertEquals("modelMatrix", shader.modelMatrix.name)
-    assertEquals("lightPosition", shader.lightPosition.name)
+    assertEquals("modelMatrix", ExampleCartoonShader.modelMatrix.name)
+    assertEquals("lightPosition", ExampleCartoonShader.lightPosition.name)
   }
 }

--- a/shader/src/test/scala/com/jsuereth/gl/shaders/TestStructUniformShader.scala
+++ b/shader/src/test/scala/com/jsuereth/gl/shaders/TestStructUniformShader.scala
@@ -1,0 +1,57 @@
+import org.junit.Test
+import org.junit.Assert._
+
+import com.jsuereth.gl.shaders._
+import com.jsuereth.gl.math._
+import com.jsuereth.gl.io._
+
+/** This is our target syntax. */
+import com.jsuereth.gl.math._
+import delegate com.jsuereth.gl.math._
+
+case class Material(kd: Float, ks: Float, color: Vec3[Float]) derives ShaderUniformLoadable
+object ExampleStructShader extends DslShaderProgram {
+  val material = Uniform[Material]()
+  val (vertexShaderCode, fragmentShaderCode) = defineShaders {
+    val inPosition = Input[Vec3[Float]](location=0)
+    glPosition(Vec4(inPosition, 1f))
+    fragmentShader {
+      Output("color", 0, Vec4(material().color, 1f))
+    }
+  }
+}
+
+class TestStructs {
+  @Test def extractVertexShader(): Unit = {
+    assertEquals(
+"""#version 300 es
+
+precision highp float;
+precision highp int;
+
+layout (location = 0) in vec3 inPosition;
+void main() {
+  gl_Position = vec4(inPosition,1.0);
+}""", ExampleStructShader.vertexShaderCode)
+  }
+  @Test def extractPixelShader(): Unit = {
+    assertEquals(
+"""#version 300 es
+
+precision highp float;
+precision highp int;
+
+struct Material {
+  float kd;
+  float ks;
+  vec3 color;
+};
+layout (location = 0) out vec4 color;
+uniform Material material;
+void main() {
+  color = vec4((material).color,1.0);
+}""", ExampleStructShader.fragmentShaderCode)
+
+    assertEquals("material", ExampleStructShader.material.name)
+  }
+}


### PR DESCRIPTION
When a uniform is defined as a case class, where all members are either "plain old data" GLSL types, or "struct"-like, then we can define a uniform loader to send in the entire structure into GLSL and treat it as such.

This could be implemented with input-blocks, but this seems like a better stepping stone.